### PR TITLE
Update van_turf_import.yaml

### DIFF
--- a/examples/van_turf_import.yaml
+++ b/examples/van_turf_import.yaml
@@ -3,8 +3,8 @@ workflow:
   input:
     # ngpvan credential id - find under https://platform.civisanalytics.com/spa/credentials
     - ngpvan_credential:
-    # ngpvan database mode; 0 for MyVoterfile, 1 for MyCampaign
-    - ngpvan_mode: 1
+    # ngpvan database mode; "0" for MyVoterfile, "1" for MyCampaign
+    - ngpvan_mode: "1"
     # remote_host -  find under https://platform.civisanalytics.com/spa/remote_hosts
     - cluster:
     # database credential id - find under https://platform.civisanalytics.com/spa/credentials


### PR DESCRIPTION
Adding quotes around the import mode parameter.  Platform wants this to be a string.  In the Platform UI we automatically turn parameters into strings but in YAML it gets passed as an integer so we need to correct that here. 