### PR TITLE
[CIVIS-9253] Change default -> target in profile

### DIFF
--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,5 +1,5 @@
 dbt-civis:
-  default: redshift_adapter
+  target: redshift_adapter
   outputs:
     redshift_adapter:
       type: "{{ env_var('DATABASE_TYPE') }}"


### PR DESCRIPTION
Allow dbt jobs using this example to leave the `target` field in Platform blank by properly setting a default target. The dbt selector for naming the default target is called `target`, not `default`.

Docs: https://docs.getdbt.com/docs/core/connect-data-platform/profiles.yml